### PR TITLE
Fix core single-file processing and safe transcript generator

### DIFF
--- a/examples/genai_training_transcript/src/training_manager/core.py
+++ b/examples/genai_training_transcript/src/training_manager/core.py
@@ -37,11 +37,17 @@ class TrainingManager:
         # Create output directories via MCP (fallback to local for now)
         await self._ensure_directories_exist(mcp_server, [cleaned_dir, metadata_dir])
 
-        # List raw transcript files via MCP
-        modules = await self._list_transcript_files(mcp_server, transcripts_dir)
+        # List raw transcript files via MCP for multi-module courses
+        if is_single_file:
+            # modules already contains info for the single transcript file
+            transcript_files = modules
+        else:
+            transcript_files = await self._list_transcript_files(
+                mcp_server, transcripts_dir
+            )
 
         metadata_list = []
-        for module_info in modules:
+        for module_info in transcript_files:
             if is_single_file:
                 module_file = module_info["filename"]
                 module_path = module_info["filepath"]

--- a/examples/genai_training_transcript/src/transcript_generator/tools/transcript_generator.py
+++ b/examples/genai_training_transcript/src/transcript_generator/tools/transcript_generator.py
@@ -7,7 +7,13 @@ from pydantic import BaseModel
 
 try:
     from agents import Agent, Runner
-    _AGENTS_SDK_AVAILABLE = True
+    import inspect
+    import os
+
+    _AGENTS_SDK_AVAILABLE = (
+        inspect.iscoroutinefunction(getattr(Runner, "run", None))
+        and os.environ.get("OPENAI_API_KEY")
+    )
 except ImportError:
     _AGENTS_SDK_AVAILABLE = False
 


### PR DESCRIPTION
## Summary
- avoid re-listing modules for single-file courses
- disable Agents SDK usage in transcript generator when no API key is available

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e3c6b3fc83329ad350b890c006ce