### PR TITLE
🔧 Fix AI Developer Guidelines per Codex feedback

### DIFF
--- a/examples/genai_training_transcript/AI_DEVELOPER_GUIDELINES.md
+++ b/examples/genai_training_transcript/AI_DEVELOPER_GUIDELINES.md
@@ -20,13 +20,13 @@ AI developers must follow the same professional standards as human developers. N
 #### **Before Creating Any PR:**
 ```bash
 # 1. Unit Tests
-poetry run pytest tests/ -v
+poetry run pytest examples/genai_training_transcript/tests/ -v
 
 # 2. Integration Test - App Must Still Run
-cd src && python run.py --config ../config.yaml
+cd src && poetry run python run.py --config ../config.yaml
 
 # 3. Import Validation
-python -c "from existing_modules import *; print('✅ No breaking changes')"
+poetry run python -c "from existing_modules import *; print('✅ No breaking changes')"
 
 # 4. Existing Functionality Check
 # Test that critical workflows still work
@@ -107,4 +107,3 @@ python -c "from existing_modules import *; print('✅ No breaking changes')"
 
 🤖 This document applies to all AI coding agents collaborating on this project.
 
-Co-Authored-By: Experienced Tech Lead who's seen this before 😉


### PR DESCRIPTION
## Summary
Address specific feedback from Codex's review of PR #65:

• Use `poetry run` for all Python commands in testing protocols
• Fix test path to correct project structure
• Remove informal signature as requested
• Keep CLAUDE.md (authorized by project owner)

## Changes Made
✅ **Command Updates**: All Python commands now use `poetry run`
- `pytest` → `poetry run pytest examples/genai_training_transcript/tests/`
- `python run.py` → `poetry run python run.py`
- Import validation → `poetry run python -c`

✅ **Path Corrections**: Fixed test path to match actual project structure
✅ **Professional Tone**: Removed informal signature line
✅ **CLAUDE.md Preserved**: Per owner authorization (not violating modification rules)

## Verification
- [x] Commands are project-appropriate
- [x] Poetry environment usage consistent
- [x] Professional documentation standards maintained
- [x] All Codex feedback addressed

🤖 Generated with [Claude Code](https://claude.ai/code)