### PR TITLE
🐛 Fix Training Manager Import Errors and Add .env Support

### DIFF
--- a/examples/genai_training_transcript/README.md
+++ b/examples/genai_training_transcript/README.md
@@ -43,12 +43,65 @@ export LANGSMITH_PROJECT=story-ops
 
 ### 1. Prepare Training Data
 
-Run the training manager to preprocess raw transcripts:
+The training manager preprocesses raw transcripts into cleaned content and metadata. It supports two input formats:
+
+#### Single File Mode
+Process individual transcript files:
 
 ```bash
-poetry run run_training_manager \
-  --course-path data/training_courses/<course_name> \
-  [--overwrite]
+# Process full course transcripts
+poetry run run_training_manager --course-path data/training_courses/full/Course_Name.txt
+
+# Process smoke test transcripts (smaller, faster)
+poetry run run_training_manager --course-path data/training_courses/smoke_tests/Course_Smoke_Test.txt
+
+# Process individual chapters
+poetry run run_training_manager --course-path data/training_courses/chapters/Course_Chapter1_Topic.txt
+```
+
+#### Multi-Module Directory Mode
+Process courses with multiple transcript files:
+
+```bash
+# Process multi-module courses (expects CourseID - Title/transcripts/*.txt structure)
+poetry run run_training_manager --course-path "data/training_courses/CourseID - Course Title"
+```
+
+#### Options
+- `--overwrite`: Regenerate existing cleaned transcripts and metadata
+- `--mcp-endpoint`: MCP server endpoint (default: stdio://)
+
+#### Input Data Structure
+
+The system expects training data organized as follows:
+
+```
+data/training_courses/
+├── full/                          # Complete course transcripts (single file mode)
+│   ├── Course_Name.txt
+│   └── Another_Course.txt
+├── smoke_tests/                   # Quick test transcripts (single file mode)
+│   ├── Course_Smoke_Test.txt
+│   └── Another_Smoke_Test.txt
+├── chapters/                      # Individual chapter files (single file mode)
+│   ├── Course_Chapter1_Topic.txt
+│   └── Course_Chapter2_Advanced.txt
+└── CourseID - Course Title/       # Multi-module course (directory mode)
+    └── transcripts/
+        └── module1_en - Course - 1 - Introduction.txt
+```
+
+#### Output Structure
+
+The training manager generates:
+
+```
+output/
+└── <CourseID>/
+    ├── cleaned_transcripts/       # Preprocessed Markdown files
+    │   └── <module_id>.md
+    └── metadata/                  # Course metadata and index
+        └── index.json
 ```
 
 ### 2. Generate Training Content

--- a/examples/genai_training_transcript/pyproject.toml
+++ b/examples/genai_training_transcript/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 packages = [{include = "src"}]
 
 [tool.poetry.scripts]
-run_training_manager = "training_manager.main:cli_main"
+run_training_manager = "src.training_manager.main:cli_main"
 transcript-generator = "cli.transcript_generator_cli:main"
 
 [tool.poetry.dependencies]

--- a/examples/genai_training_transcript/src/training_manager/main.py
+++ b/examples/genai_training_transcript/src/training_manager/main.py
@@ -9,6 +9,13 @@ import os
 import shutil
 import sys
 
+# Load environment variables from .env file
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # python-dotenv not available, skip loading
+
 # allow running as module
 if __name__ == "__main__" and __package__ is None:
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -18,7 +25,7 @@ if __name__ == "__main__" and __package__ is None:
 from agents import gen_trace_id, trace
 from agents.mcp import MCPServerStdio
 
-from training_manager import TrainingManager
+from .core import TrainingManager
 
 
 async def main() -> None:
@@ -47,9 +54,11 @@ async def main() -> None:
             raise RuntimeError(
                 "npx is required for stdio MCP filesystem server (npm install -g npx)"
             )
+        # For single files, use parent directory for MCP server
+        mcp_root = os.path.dirname(args.course_path) if os.path.isfile(args.course_path) else args.course_path
         mcp_params = {
             "command": "npx",
-            "args": ["-y", "@modelcontextprotocol/server-filesystem", args.course_path],
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", mcp_root],
         }
         mcp_server = MCPServerStdio(params=mcp_params, name="Training Courses Filesystem")
     elif args.mcp_endpoint.startswith("evernote://"):


### PR DESCRIPTION
## Summary
Fixes critical import errors and missing environment variable support in the Training Manager, enabling both single file and directory processing modes.

Resolves #80

## Changes Made

### 🔧 Core Fixes
- **Fixed Poetry script import path**: `training_manager.main` → `src.training_manager.main` in `pyproject.toml`
- **Added automatic .env loading**: Training manager now loads environment variables from `.env` file automatically
- **Fixed single file mode**: MCP server now uses parent directory for single file inputs

### 📚 Documentation
- **Updated README.md**: Added comprehensive Training Manager usage documentation
- **Generic examples**: Removed specific course references, using generic placeholders
- **Input/output structure**: Documented expected data organization and generated outputs

## Technical Details

### Import Path Fix
```diff
- run_training_manager = "training_manager.main:cli_main"
+ run_training_manager = "src.training_manager.main:cli_main"
```

### Environment Loading
```python
# Load environment variables from .env file
try:
    from dotenv import load_dotenv
    load_dotenv()
except ImportError:
    pass  # python-dotenv not available, skip loading
```

### Single File Support
```python
# For single files, use parent directory for MCP server
mcp_root = os.path.dirname(args.course_path) if os.path.isfile(args.course_path) else args.course_path
```

## Testing

### ✅ Single File Mode
```bash
poetry run run_training_manager --course-path data/training_courses/smoke_tests/Course_Smoke_Test.txt
```

### ✅ Directory Mode  
```bash
poetry run run_training_manager --course-path "data/training_courses/CourseID - Course Title"
```

### ✅ Environment Variables
- Automatic loading of `OPENAI_API_KEY` from `.env`
- No manual export required

## Output
Successfully generates:
- `output/<CourseID>/cleaned_transcripts/<module_id>.md`
- `output/<CourseID>/metadata/index.json`

🤖 Generated with [Claude Code](https://claude.ai/code)