### PR TITLE
📚 Fix Integration Tests Documentation - Correct Execution Method

### DIFF
--- a/examples/genai_training_transcript/integration_tests/README.md
+++ b/examples/genai_training_transcript/integration_tests/README.md
@@ -35,15 +35,21 @@ npx @modelcontextprotocol/server-filesystem data/training_courses/
 
 ### Running Tests
 
+Integration tests are designed as standalone Python scripts, not pytest tests:
+
 ```bash
 # Run all integration tests
-poetry run pytest integration_tests/ -v
+for test in integration_tests/integration_test_*.py; do
+    echo "=== Running $test ==="
+    poetry run python "$test"
+    echo
+done
 
 # Run specific integration test
-poetry run pytest integration_tests/integration_test_workflow_orchestrator.py -v
+poetry run python integration_tests/integration_test_workflow_orchestrator.py
 
-# Run with detailed output
-poetry run pytest integration_tests/ -v -s
+# Run CLI end-to-end test
+poetry run python integration_tests/integration_test_cli_end_to_end.py
 ```
 
 ## Test Data


### PR DESCRIPTION
## Summary
Fixes incorrect documentation for running integration tests. Updates from broken `pytest` commands to working direct Python script execution.

Resolves #84

## Problem Fixed

**Issue**: Documentation showed `pytest` commands that collected 0 tests
```bash
# ❌ This doesn't work
poetry run pytest integration_tests/ -v
# Result: collected 0 items
```

**Root Cause**: Integration tests are standalone Python scripts with `if __name__ == "__main__"` blocks, not pytest-compatible tests.

## Changes Made

### 📝 Updated `integration_tests/README.md`

**Before** (broken):
```bash
# Run all integration tests
poetry run pytest integration_tests/ -v

# Run specific integration test  
poetry run pytest integration_tests/integration_test_workflow_orchestrator.py -v
```

**After** (working):
```bash
# Run all integration tests
for test in integration_tests/integration_test_*.py; do
    echo "=== Running $test ==="
    poetry run python "$test"
    echo
done

# Run specific integration test
poetry run python integration_tests/integration_test_workflow_orchestrator.py

# Run CLI end-to-end test
poetry run python integration_tests/integration_test_cli_end_to_end.py
```

## Verification

✅ **Before fix**: `poetry run pytest integration_tests/ -v` → "no tests collected"  
✅ **After fix**: `poetry run python integration_tests/integration_test_cli_end_to_end.py` → Test executes successfully

## Impact

- **Developers**: Can now follow documentation to run integration tests
- **CI/CD**: Correct commands available for automated testing
- **Development workflow**: Integration testing becomes reliable and documented

## Files Changed

- `integration_tests/README.md`: Updated execution instructions

## Testing

Verified that:
1. New commands work correctly
2. Individual test execution functions as documented  
3. Loop command runs multiple tests sequentially

🤖 Generated with [Claude Code](https://claude.ai/code)